### PR TITLE
Exception: undefined method `info' for nil:NilClass in run_import 

### DIFF
--- a/lib/rails_admin_import.rb
+++ b/lib/rails_admin_import.rb
@@ -5,11 +5,11 @@ require "rails_admin_import/config"
 module RailsAdminImport
   def self.config(entity = nil, &block)
     if entity
-    RailsAdminImport::Config.model(entity, &block)
+      RailsAdminImport::Config.model(entity, &block)
     elsif block_given? && ENV['SKIP_RAILS_ADMIN_INITIALIZER'] != "true"
       block.call(RailsAdminImport::Config)
-  else
-    RailsAdminImport::Config
+    else
+      RailsAdminImport::Config
     end
   end
 

--- a/lib/rails_admin_import/import_logger.rb
+++ b/lib/rails_admin_import/import_logger.rb
@@ -1,0 +1,14 @@
+module RailsAdminImport
+  class ImportLogger
+    attr_reader :logger
+
+    def initialize(log_file_name = 'rails_admin_import.log')
+      @logger = Logger.new("#{Rails.root}/log/#{log_file_name}") if RailsAdminImport.config.logging
+    end
+    
+    def info(message)
+      @logger.info message if RailsAdminImport.config.logging
+    end
+ 
+  end
+end


### PR DESCRIPTION
Resolved Exception:

Completed 500 Internal Server Error in 96ms
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/callbacks.rb:480:in `_run__432446605125107763__process_action__934790385274361738__callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/notifications/instrumenter.rb:20:in`instrument'
NoMethodError (undefined method `info' for nil:NilClass):
vendor/bundle/ruby/1.9.1/bundler/gems/rails_admin_import-90f967a3700f/lib/rails_admin_import.rb:42:in`block (2 levels) in class:Import'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.6/lib/active_support/notifications.rb:123:in `instrument'
vendor/bundle/ruby/1.9.1/bundler/gems/rails_admin_import-90f967a3700f/lib/rails_admin_import/import.rb:130:in`rescue in 

`RailsAdminImport.config.logging` was missing in rescue block of `run_import` method 
https://github.com/stephskardal/rails_admin_import/blob/master/lib/rails_admin_import/import.rb#L130

I've DRyed out logging functionality by moving it in separate class. 
