### PR TITLE
Disallow import :all before allowing just few models import

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ end
 * If you are using CanCanCan for authorization, add to ability.rb to specify which models can be imported:
 
 ```ruby
+cannot :import, :all
 can :import, [User, Model1, Model2]
 ```
 


### PR DESCRIPTION
The example wouldn't work if the ability doesn't include a `cannot` before the `can`.