### PR TITLE
file_importer.rb crash when logger is activate

### DIFF
--- a/lib/rails_admin_import/formats/file_importer.rb
+++ b/lib/rails_admin_import/formats/file_importer.rb
@@ -37,7 +37,9 @@ module RailsAdminImport
 
       def copy_uploaded_file_to_log_dir
         copy_filename = "#{Time.now.strftime("%Y-%m-%d-%H-%M-%S")}-import.csv"
-        copy_path = File.join(Rails.root, "log", "import", copy_filename)
+        dir_path = File.join(Rails.root, "log", "import")
+        FileUtils.mkdir_p(dir_path)
+        copy_path = File.join(dir_path, copy_filename)
         FileUtils.copy(filename, copy_path)
       end
     end


### PR DESCRIPTION
When logger is active, the method copy_uploaded_file_to_log_dir has a problem when dir import does not exist, so I use the FileUtils.makedir_p to create it and prevent FileUtils.cp not to crash