### PR TITLE
Enforce line item limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The expected rows and columns are the same as for the CSV format (first line con
 
 * __logging__ (default `false`): Save a copy of each imported file to log/import and a detailed import log to log/rails_admin_import.log
 
-* __line_item_limit__ (default `1000`): max number of items that can be imported at one time. TODO: Currently this is suggested but not enforced.
+* __line_item_limit__ (default `1000`): max number of items that can be imported at one time.
 
 * __rollback_on_error__ (default `false`): import records in a transaction and rollback if there is one error. Only for ActiveRecord, not Mongoid.
 

--- a/config/locales/import.en.yml
+++ b/config/locales/import.en.yml
@@ -34,6 +34,7 @@ en:
         create: "Failed to create %{name}: %{error}"
         update: "Failed to update %{name}: %{error}"
         general: "Error during import: %{error}"
+        line_item_limit: "Please limit upload file to %{limit} line items."
         old_import_hook: >
           The import hook %{model}.%{method} should take only 1 argument.
           Data may not imported correctly.

--- a/lib/rails_admin_import/importer.rb
+++ b/lib/rails_admin_import/importer.rb
@@ -16,10 +16,13 @@ module RailsAdminImport
       begin
         init_results
 
-        # TODO: re-implement file size check
-        # if file_check.readlines.size > RailsAdminImport.config.line_item_limit
-        #   return results = { :success => [], :error => ["Please limit upload file to #{RailsAdminImport.config.line_item_limit} line items."] }
-        # end
+
+        if records.count > RailsAdminImport.config.line_item_limit
+          return results = {
+            success: [],
+            error: ["Please limit upload file to #{RailsAdminImport.config.line_item_limit} line items."]
+          }
+        end
 
         with_transaction do
           records.each do |record|
@@ -64,7 +67,7 @@ module RailsAdminImport
     def import_record(record)
       if update_lookup && !record.has_key?(update_lookup)
         raise UpdateLookupError, I18n.t("admin.import.missing_update_lookup")
-      end 
+      end
 
       object = find_or_create_object(record, update_lookup)
       action = object.new_record? ? :create : :update
@@ -142,7 +145,7 @@ module RailsAdminImport
              name: result_count,
                action: I18n.t("admin.actions.import.done"))
     end
-    
+
     def perform_model_callback(object, method_name, record)
       if object.respond_to?(method_name)
         # Compatibility: Old import hook took 2 arguments.
@@ -175,7 +178,7 @@ module RailsAdminImport
       model = import_model.model
       object = if update.present?
                  model.where(update => record[update]).first
-               end 
+               end
 
       if object.nil?
         object = model.new(new_attrs)
@@ -221,4 +224,3 @@ module RailsAdminImport
     end
   end
 end
-

--- a/lib/rails_admin_import/importer.rb
+++ b/lib/rails_admin_import/importer.rb
@@ -20,7 +20,7 @@ module RailsAdminImport
         if records.count > RailsAdminImport.config.line_item_limit
           return results = {
             success: [],
-            error: ["Please limit upload file to #{RailsAdminImport.config.line_item_limit} line items."]
+            error: [I18n.t('admin.import.import_error.line_item_limit', limit: RailsAdminImport.config.line_item_limit)]
           }
         end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -28,6 +28,19 @@ describe "Rails Admin Config" do
 
   describe "line_item_limit" do
     it_behaves_like "a global config option", "line_item_limit", 500
+
+    it 'returns an error if the provided file exceeds the line limit', type: :request do
+      RailsAdmin.config do |config|
+        config.configure_with :import do |config|
+          config.line_item_limit = 1
+        end
+      end
+
+      file = fixture_file_upload('balls.csv', 'text/plain')
+      post '/admin/ball/import', file: file
+      expect(response.body).to include 'Please limit upload file to 1 line items.'
+      expect(Ball.count).to eq 0
+    end
   end
 
   describe "rollback_on_error" do


### PR DESCRIPTION
Picking up from the todo [here](https://github.com/stephskardal/rails_admin_import/blob/master/lib/rails_admin_import/importer.rb#L19-L22) - this adds enforcement for the amount of records that may be imported at a time (as well as a locale for the message returned to the user)

Looks like my text editor added some whitespace changes, you can see the diff without those [here](https://github.com/stephskardal/rails_admin_import/compare/master...codealchemy:line-item-limit?w=1).