### PR TITLE
Restricting the list of possible mapping_key values for a model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ log/*.log
 pkg/
 spec/dummy_app/log
 .idea/
+*.gem

--- a/app/views/rails_admin/main/import.html.haml
+++ b/app/views/rails_admin/main/import.html.haml
@@ -52,7 +52,7 @@
             = t("admin.import.mapping")
           .col-sm-10.controls
             = select_tag "associations[#{field.name}]",
-              options_for_select(@import_model.associated_model_fields(field).map(&:name),
+              options_for_select(@import_model.associated_model_fields(field),
               @import_model.associated_config(field).mapping_key.to_s), data: { enumeration: true }
 
   %br

--- a/lib/rails_admin_import/config/sections/import.rb
+++ b/lib/rails_admin_import/config/sections/import.rb
@@ -9,8 +9,12 @@ module RailsAdmin
           :name
         end
 
+        register_instance_option(:mapping_key_list) do
+          []
+        end
+
         register_instance_option(:default_excluded_fields) do
-          [:id, :_id, :created_at, :updated_at]
+          [:id, :_id, :created_at, :updated_at, :c_at, :u_at]
         end
       end
     end

--- a/lib/rails_admin_import/import_model.rb
+++ b/lib/rails_admin_import/import_model.rb
@@ -63,7 +63,11 @@ module RailsAdminImport
     end
 
     def update_lookup_field_names
-      @update_lookup_field_names ||= model_fields.map(&:name) + belongs_to_fields.map(&:foreign_key)
+      if @config.mapping_key_list.present?
+        @update_lookup_field_names = @config.mapping_key_list
+      else
+        @update_lookup_field_names ||= model_fields.map(&:name) + belongs_to_fields.map(&:foreign_key)
+      end
     end
 
     def associated_object(field, mapping_field, value)
@@ -82,9 +86,13 @@ module RailsAdminImport
 
     def associated_model_fields(field)
       @associated_fields ||= {}
-      @associated_fields[field] ||= associated_config(field).visible_fields.select { |f|
-        !f.association?
-      }
+      if associated_config(field).mapping_key_list.present?
+        @associated_fields[field] ||= associated_config(field).mapping_key_list
+      else
+        @associated_fields[field] ||= associated_config(field).visible_fields.select { |f|
+          !f.association?
+        }.map(&:name)
+      end
     end
 
     def has_multiple_values?(field_name)


### PR DESCRIPTION
Added concept of mapping_key_list which allows to restrict which fields can be used for mapping.
Example - User model with Devise has lots of attributes which you might want to import but don't want to use for mapping.  

Feel free to change the name if you do not like mapping_key_list.  It would be also helpful to update the docs to explain how to use it via array 
      mapping_key :email
      mapping_key_list [:email, :some_unique_id] 

Also added :c_at and :u_at to default_excluded_fields, used in Mongoid::Timestamps::Short
