### PR TITLE
Updated code that lists target encodings

### DIFF
--- a/app/views/rails_admin/main/import.html.haml
+++ b/app/views/rails_admin/main/import.html.haml
@@ -24,7 +24,7 @@
       %label.col-sm-2.control-label{for: "encoding"}= t("admin.import.encoding")
       .col-sm-10.controls
         = select_tag 'encoding',
-          options_for_select(RailsAdmin::CSVConverter::TARGET_ENCODINGS),
+          options_for_select(Encoding.name_list.sort),
           include_blank: true, data: { enumeration: true }
         %p.help-block= t('admin.import.help.encoding', name: 'UTF-8')
     .form-group.control-group


### PR DESCRIPTION
The previous code that was supposed to fetch a list of encodings was using a constant from Rails Admin that is no longer available. This caused an error when using an up-to-date version of Rails Admin. This fix fetches encodings the same way Rails Admin does nowadays.