### PR TITLE
Remove haml dependency

### DIFF
--- a/rails_admin_import.gemspec
+++ b/rails_admin_import.gemspec
@@ -1,7 +1,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
 require "rails_admin_import/version"
- 
+
 Gem::Specification.new do |s|
   s.name = "rails_admin_import"
   s.version = RailsAdminImport::VERSION
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 3.2'
   s.add_dependency 'rails_admin', '>= 0.6.6'
-  s.add_dependency 'haml', '~> 4.0'
   s.add_dependency 'rchardet', '~> 1.6'
   s.add_dependency 'simple_xlsx_reader', '~> 1.0'
 end


### PR DESCRIPTION
Specifying haml dependency would cause many problems.
As rails_admin already requires this gem, you can let them handle this dependency.

Ref.:

https://github.com/sferik/rails_admin/issues/2880
https://github.com/sferik/rails_admin/pull/2876