### PR TITLE
Skip empty columns rather than break

### DIFF
--- a/lib/rails_admin_import/formats/xlsx_importer.rb
+++ b/lib/rails_admin_import/formats/xlsx_importer.rb
@@ -33,7 +33,7 @@ module RailsAdminImport
       def convert_to_attributes(row)
         row_with_headers = @headers.zip(row)
         row_with_headers.each_with_object({}) do |(field, value), record|
-          break if field.nil?
+          next if field.nil?
           field = field.to_sym
           if import_model.has_multiple_values?(field)
             field = import_model.pluralize_field(field)


### PR DESCRIPTION
with empty column will raise follow error

```
Error during import: undefined method `has_key?' for nil:NilClass (/home/abcam/rails_apps/adms_staging/releases/92/vendor/bundle/ruby/2.4.0/bundler/gems/rails_admin_import-b8bfec87cff4/lib/rails_admin_import/importer.rb:68:in `import_record')
```