### PR TITLE
Switch to using CharlockHolmes for character encoding detection

### DIFF
--- a/lib/rails_admin_import/formats/csv_importer.rb
+++ b/lib/rails_admin_import/formats/csv_importer.rb
@@ -1,4 +1,5 @@
 require "csv"
+require "charlock_holmes"
 
 module RailsAdminImport
   module Formats
@@ -53,9 +54,9 @@ module RailsAdminImport
       end
 
       def detect_encoding
-        charset = CharDet.detect File.read(filename)
-        if charset["confidence"] > 0.6
-          from_encoding = charset["encoding"]
+        charset = CharlockHolmes::EncodingDetector.detect File.read(filename)
+        if charset[:confidence] > 0.6
+          from_encoding = charset[:encoding]
           from_encoding = "UTF-8" if from_encoding == "ascii"
         end
         from_encoding

--- a/rails_admin_import.gemspec
+++ b/rails_admin_import.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 3.2'
   s.add_dependency 'rails_admin', '>= 0.6.6'
-  s.add_dependency 'rchardet', '~> 1.6'
+  s.add_dependency 'charlock_holmes', '~> 0.6'
   s.add_dependency 'simple_xlsx_reader', '~> 1.0'
 end

--- a/spec/dummy_app/Gemfile.lock
+++ b/spec/dummy_app/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
-  remote: ../../
+  remote: ../..
   specs:
-    rails_admin_import (2.0.0)
+    rails_admin_import (2.1.0)
+      charlock_holmes (~> 0.6)
       rails (>= 3.2)
       rails_admin (>= 0.6.6)
-      rchardet (~> 1.6)
       simple_xlsx_reader (~> 1.0)
 
 GEM
@@ -51,6 +51,7 @@ GEM
     bson (4.2.2)
     builder (3.2.3)
     byebug (9.1.0)
+    charlock_holmes (0.7.6)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -161,9 +162,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rchardet (1.6.1)
     remotipart (1.3.1)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -175,7 +175,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    simple_xlsx_reader (1.0.2)
+    simple_xlsx_reader (1.0.4)
       nokogiri
       rubyzip
     sprockets (3.7.1)
@@ -212,4 +212,4 @@ DEPENDENCIES
   uglifier (>= 1.3)
 
 BUNDLED WITH
-   1.12.5
+   1.16.2


### PR DESCRIPTION
rchardet uses [LGPL](https://github.com/jmhodges/rchardet/blob/master/LGPL-LICENSE.txt), which doesn't align with the license for this gem (MIT - which is the same as [`rails`](https://github.com/rails/rails/blob/master/MIT-LICENSE) and [`rails_admin`](https://github.com/sferik/rails_admin/blob/master/LICENSE.md)) and can be fairly restrictive for uses in private projects.

This updates to use CharlockHolmes - the interface of which is effectively the same and is on an [MIT 
license](https://github.com/brianmario/charlock_holmes/blob/master/LICENSE) as well.