### PR TITLE
README: In a lambda, return (example code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,7 @@ RailsAdmin.config do |config|
     config.update_if_exists = false
     config.rollback_on_error = false
     config.header_converter = lambda do |header|
-      # check for nil/blank headers
-      next if header.blank?
-      header.parameterize.underscore
+      header.parameterize.underscore if header.present?
     end
     config.csv_options = {}
   end


### PR DESCRIPTION
This PR changes the configuration example in the README to return `nil` or a string.

The `next` is not what we want in a lambda context.