### PR TITLE
Remove BOM from CSV file.

### DIFF
--- a/lib/rails_admin_import/formats/csv_importer.rb
+++ b/lib/rails_admin_import/formats/csv_importer.rb
@@ -44,6 +44,8 @@ module RailsAdminImport
             detect_encoding
           end
 
+        from_encoding = "bom|" + from_encoding if from_encoding.start_with?("UTF-")
+
         to_encoding = import_model.abstract_model.encoding
 
         if from_encoding && from_encoding != to_encoding


### PR DESCRIPTION
Exporting CSV from Microsoft Office Excel with UTF-8 encoding results in a file with BOM at the beginning.
In order to handle Japanese correctly, we often use UTF-8 BOM in CSV output, but the current version does not work properly and we are troubled.
