### PR TITLE
fix: pass new_attrs instead of record to before_import_attributes hook

### DIFF
--- a/lib/rails_admin_import/importer.rb
+++ b/lib/rails_admin_import/importer.rb
@@ -205,10 +205,10 @@ module RailsAdminImport
 
       if object.nil?
         object = model.new
-        perform_model_callback(object, :before_import_attributes, record)
+        perform_model_callback(object, :before_import_attributes, new_attrs)
         object.attributes = new_attrs
       else
-        perform_model_callback(object, :before_import_attributes, record)
+        perform_model_callback(object, :before_import_attributes, new_attrs)
         object.attributes = new_attrs.except(update.map(&:to_sym))
       end
       object


### PR DESCRIPTION
Passing record makes the hook unable to modify imported attributes.

Fix #123 