### PR TITLE
fix: allow importing 'false' values

### DIFF
--- a/lib/rails_admin_import/importer.rb
+++ b/lib/rails_admin_import/importer.rb
@@ -206,7 +206,7 @@ module RailsAdminImport
 
       field_names = import_model.model_fields.map(&:name)
       new_attrs = record.select do |field_name, value|
-        field_names.include?(field_name) && !value.blank?
+        field_names.include?(field_name) && (!value.blank? || value == false)
       end
 
       if object.new_record?


### PR DESCRIPTION
Currently fields are rejected based on `#blank?`. `false.blank?` equals `true`, so false values are discarded.

https://github.com/stephskardal/rails_admin_import/blob/5a536c3de0039bf89581cf393cd44e64882b8baa/lib/rails_admin_import/importer.rb#L208-L210