### PR TITLE
Fix flash messsages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem 'rspec', '~> 3.10'
   gem 'rspec-rails', '~> 5.0'
   gem 'factory_bot_rails', '~> 6.2'
+  gem 'factory_bot', '< 6.4'
   gem 'database_cleaner-active_record', require: false
   gem 'database_cleaner-mongoid', require: false
 end

--- a/app/views/rails_admin/main/import.html.erb
+++ b/app/views/rails_admin/main/import.html.erb
@@ -11,7 +11,7 @@
 %>
 
 <%= render "results" %>
-<%= form_tag import_path(@abstract_model), :multipart => true, class: 'form-horizontal denser' do %>
+<%= form_tag import_path(@abstract_model), :multipart => true, class: 'form-horizontal denser', data: { turbo: false } do %>
   <input name="send_data" type="hidden" value="true">/</input>
   <fieldset>
     <legend>

--- a/app/views/rails_admin/main/import.html.erb
+++ b/app/views/rails_admin/main/import.html.erb
@@ -53,7 +53,7 @@
         <%= t("admin.import.update_if_exists") %>
       </label>
       <div class="col-sm-10 controls">
-        <%= check_box_tag :update_if_exists, '1', RailsAdminImport.config.update_if_exists, :class => "form-control" %>
+        <%= check_box_tag :update_if_exists, '1', RailsAdminImport.config.update_if_exists %>
         <p class="help-block">
           <%= t('admin.import.help.update_if_exists') %>
         </p>


### PR DESCRIPTION
## Fix missing flash messages

With Rails admin 3, turbo-rails is enabled and flash message was not displayed in rails_admin_import form.
This change turns off turbo-rails for rails_admin_import form.

Fixes https://github.com/stephskardal/rails_admin_import/issues/141

cd1760574e60432104360f1126d41f401310c4f6

## Fix checkbox corruption

"update_if_exists" checkbox was very wide.

https://github.com/stephskardal/rails_admin_import/commit/8d1e2db466813dd9222c71f52ce8dffe528d0f3a

## Fix CI failure

Latest factory_bot does not work with Ruby 2.7,
so use factory_bot 6.3 with Ruby 2.7 on CI

91a8d537bd11a5fd3dd2771cd6cbb75f195b03e2
